### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ and
 ```js
 // ProbotFunction/index.js
 const {
-  createAzureFunctionsMiddleware,
+  createAzureFunction,
   createProbot,
 } = require("@probot/adapter-azure-functions");
 const app = require("../app");
-module.exports = createAzureFunctionsMiddleware(app, {
+module.exports = createAzureFunction(app, {
   probot: createProbot(),
 });
 ```
@@ -58,9 +58,9 @@ For an example Probot App continuously deployed to Azure Functions, see https://
 
 ## How it works
 
-`@probot/adapter-azure-functions` exports everything that [`probot`](https://github.com/probot/probot/#readme) does plus `createAzureFunctionsMiddleware`.
+`@probot/adapter-azure-functions` exports everything that [`probot`](https://github.com/probot/probot/#readme) does plus `createAzureFunction`.
 
-`createAzureFunctionsMiddleware` slightly differs from Probot's built-in `createNodeModdleware`, as an Azure function does receives slightly different parameters.
+`createAzureFunction` slightly differs from Probot's built-in `createNodeModdleware`, as an Azure function does receives slightly different parameters.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For an example Probot App continuously deployed to Azure Functions, see https://
 
 `@probot/adapter-azure-functions` exports everything that [`probot`](https://github.com/probot/probot/#readme) does plus `createAzureFunction`.
 
-`createAzureFunction` slightly differs from Probot's built-in `createNodeModdleware`, as an Azure function does receives slightly different parameters.
+`createAzureFunction` slightly differs from Probot's built-in `createNodeMiddleware`, as an Azure function does receives slightly different parameters.
 
 ## License
 


### PR DESCRIPTION
`createAzureFunctionsMiddleware` does not exist, should be replaced with
`createAzureFunction`.

Fixes #3

-----
[View rendered README.md](https://github.com/h-no/adapter-azure-functions/blob/main/README.md)